### PR TITLE
Fix `getPartitionValues` method

### DIFF
--- a/src/main/java/com/exasol/hadoop/hdfs/PartitionPathFilter.java
+++ b/src/main/java/com/exasol/hadoop/hdfs/PartitionPathFilter.java
@@ -75,7 +75,7 @@ public class PartitionPathFilter implements PathFilter {
             }
             partitionValues.put(keyVal[0], keyVal[1]);
             if (i+1<numPartitionsInPaths) {    // Don't go up if we don't enter the loop again
-                current = path.getParent();
+                current = current.getParent();
             }
         }
         return partitionValues;

--- a/src/test/java/com/exasol/hadoop/hdfs/PartitionPathFilterTest.java
+++ b/src/test/java/com/exasol/hadoop/hdfs/PartitionPathFilterTest.java
@@ -1,0 +1,33 @@
+package com.exasol.hadoop.hdfs;
+
+import com.exasol.hadoop.hcat.HCatTableColumn;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.fs.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class PartitionPathFilterTest {
+    @Test
+    public void testAccept() {
+        int numberOfPartitions = 3;
+        List<HCatTableColumn> partitionColumns = new ArrayList<>();
+
+        partitionColumns.add(new HCatTableColumn("year", "int"));
+        partitionColumns.add(new HCatTableColumn("month", "int"));
+        partitionColumns.add(new HCatTableColumn("day", "int"));
+
+        PartitionPathFilter partionPathFilter = new PartitionPathFilter(
+                partitionColumns,
+                new ArrayList<>(),
+                numberOfPartitions
+        );
+
+        Path path = new Path("metric/year=2017/month=9/day=25");
+
+        assertEquals(true, partionPathFilter.accept(path));
+    }
+}


### PR DESCRIPTION
Before the fix, the method used the same input path to get the parent which works fine
if the partitions are less than or equals to 2 partions.

In case of 3 or more partitions, the method fails to extract the partitions and hence the importer
to Exasol doesn't work.