### PR TITLE
Improve error message when establishing an hdfs connection fails.

### DIFF
--- a/src/main/java/com/exasol/hadoop/hdfs/HdfsService.java
+++ b/src/main/java/com/exasol/hadoop/hdfs/HdfsService.java
@@ -50,6 +50,7 @@ public class HdfsService {
      * Try creating a FileSystem for any of the provided hdfs urls
      */
     public static FileSystem getFileSystem(List<String> hdfsURLs, Configuration conf) throws IOException {
+        HashMap<String, Exception> exceptions = new HasMap();
         Exception lastException = null;
         for (String hdfsURL : hdfsURLs) {
             try {
@@ -66,10 +67,11 @@ public class HdfsService {
                 return realFs;
             }
             catch (Exception e) {
+                exceptions.put(hdfsURL, e);
                 lastException = e;
             }
         }
-        throw new RuntimeException("None of the provided HDFS URLs is reachable: " + hdfsURLs.toString() + ". The error for the last URL '" + hdfsURLs.get(hdfsURLs.size()-1) + "' was: " + lastException.getClass().getName() + ": " + lastException.getMessage());
+        throw new RuntimeException("None of the provided HDFS URLs is reachable: " + exceptions, lastException);
     }
 
     /**

--- a/src/main/java/com/exasol/hadoop/hdfs/HdfsService.java
+++ b/src/main/java/com/exasol/hadoop/hdfs/HdfsService.java
@@ -14,7 +14,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class HdfsService {
     
@@ -50,8 +52,9 @@ public class HdfsService {
      * Try creating a FileSystem for any of the provided hdfs urls
      */
     public static FileSystem getFileSystem(List<String> hdfsURLs, Configuration conf) throws IOException {
-        HashMap<String, Exception> exceptions = new HasMap();
+        Map<String, Exception> exceptions = new HashMap<>();
         Exception lastException = null;
+
         for (String hdfsURL : hdfsURLs) {
             try {
                 System.out.println("Filesystem to connect to: " + hdfsURL);
@@ -71,6 +74,7 @@ public class HdfsService {
                 lastException = e;
             }
         }
+        
         throw new RuntimeException("None of the provided HDFS URLs is reachable: " + exceptions, lastException);
     }
 

--- a/src/main/java/com/exasol/hadoop/hdfs/HdfsService.java
+++ b/src/main/java/com/exasol/hadoop/hdfs/HdfsService.java
@@ -74,7 +74,7 @@ public class HdfsService {
                 lastException = e;
             }
         }
-        
+
         throw new RuntimeException("None of the provided HDFS URLs is reachable: " + exceptions, lastException);
     }
 

--- a/src/test/java/com/exasol/hadoop/hdfs/HdfsServiceTest.java
+++ b/src/test/java/com/exasol/hadoop/hdfs/HdfsServiceTest.java
@@ -1,0 +1,35 @@
+package com.exasol.hadoop.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HdfsServiceTest {
+
+    @Test public void exceptionMessagesWhenHdfsIsNotAccessible() {
+
+        try {
+            HdfsService.getFileSystem(asList("hdfs://gibtsnicht", "broken:url"), new Configuration());
+
+        } catch (Exception e) {
+            String message = e.getMessage();
+            assertTrue("Contains exception message for first URL",
+                    message.contains("UnknownHostException: gibtsnicht"));
+            assertTrue("Contains exception message for second URL",
+                    message.contains("IOException: No FileSystem for scheme: broken"));
+
+            String causeMessage = e.getCause().getMessage();
+            assertTrue("Exception on last URL will be shown as exception cause.",
+                    causeMessage.contains("No FileSystem for scheme: broken"));
+        }
+
+    }
+
+}


### PR DESCRIPTION
Calling HdfsService.getFileSystem allows a list of hdfsURLs as paramaters. When the connection fails on all URLs, an exception is thrown. But only the message of the last thrown exception will be shown. With this patches the messages of all exceptions will be show.