### PR TITLE
Fix/hdfs url list for export

### DIFF
--- a/src/main/java/com/exasol/hadoop/scriptclasses/ExportIntoHiveTable.java
+++ b/src/main/java/com/exasol/hadoop/scriptclasses/ExportIntoHiveTable.java
@@ -9,10 +9,13 @@ import com.exasol.hadoop.hcat.HCatTableColumn;
 import com.exasol.hadoop.hcat.HCatTableMetadata;
 import com.exasol.hadoop.hdfs.HdfsService;
 import com.exasol.hadoop.kerberos.KerberosCredentials;
+import com.exasol.hadoop.kerberos.KerberosHadoopUtils;
 import com.exasol.utils.UdfUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.security.UserGroupInformation;
 
+import java.security.PrivilegedExceptionAction;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
@@ -65,11 +68,18 @@ public class ExportIntoHiveTable {
             ExaConnectionInformation kerberosConnection = meta.getConnection(connName);
             kerberosCredentials = new KerberosCredentials(kerberosConnection);
         }
-        Configuration conf = new Configuration();
-        if (useKerberos) {
-            conf.set("dfs.namenode.kerberos.principal", hdfsUser);
-        }
-        FileSystem fs = HdfsService.getFileSystem(hdfsAddresses, conf);
+
+        UserGroupInformation ugi = useKerberos ?
+                KerberosHadoopUtils.getKerberosUGI(kerberosCredentials) : UserGroupInformation.createRemoteUser(hdfsUser);
+        FileSystem fs = ugi.doAs(new PrivilegedExceptionAction<FileSystem>() {
+            public FileSystem run() throws Exception {
+                final Configuration conf = new Configuration();
+                if (useKerberos) {
+                    conf.set("dfs.namenode.kerberos.principal", hdfsUser);
+                }
+                return HdfsService.getFileSystem(hdfsAddresses, conf);
+            }
+        });
 
         HCatTableMetadata tableMeta = HCatMetadataService.getMetadataForTable(hcatDB, hcatTable, hcatAddress, hdfsUser, useKerberos, kerberosCredentials);
         System.out.println("tableMeta: " + tableMeta);

--- a/src/test/java/com/exasol/hadoop/scriptclasses/ExportIntoHiveTableTest.java
+++ b/src/test/java/com/exasol/hadoop/scriptclasses/ExportIntoHiveTableTest.java
@@ -3,7 +3,9 @@ package com.exasol.hadoop.scriptclasses;
 import com.exasol.ExaIterator;
 import com.exasol.ExaIteratorDummy;
 import com.exasol.ExaMetadata;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,29 +15,58 @@ import static org.mockito.Mockito.mock;
 
 public class ExportIntoHiveTableTest {
 
-	@Test(expected = RuntimeException.class)
-	public void testOptionalParams() throws Exception {
-		List<List<Object>> paramSet = new ArrayList<>();
-		List<Object> params = new ArrayList<>();
-		params.add("dummy");
-		params.add("dummy");
-		params.add("dummy");
-		params.add("dummy");
-		params.add("dummy");
-		params.add("dummy");
-		params.add("dummy");
-		params.add("dummy");
-		params.add(null); // auth connection name at position PARAM_IDX_AUTH_CONNECTION
-		params.add("dummy");
-		params.add(null); // debug address at position PARAM_IDX_DEBUG_ADDRESS
-		paramSet.add(params);
-		ExaIterator iter = new ExaIteratorDummy(paramSet);
-		ExaMetadata meta = mock(ExaMetadata.class);
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
-		try {
-			ExportIntoHiveTable.run(meta, iter);
-		} catch (NullPointerException npe) {
-			fail("A RuntimeException was expected, but not a NullPointerException!");
-		}
-	}
+    @Test(expected = RuntimeException.class)
+    public void testOptionalParams() throws Exception {
+        List<List<Object>> paramSet = new ArrayList<>();
+        List<Object> params = new ArrayList<>();
+        params.add("dummy");
+        params.add("dummy");
+        params.add("dummy");
+        params.add("dummy");
+        params.add("dummy");
+        params.add("dummy");
+        params.add("dummy");
+        params.add("dummy");
+        params.add(null); // auth connection name at position PARAM_IDX_AUTH_CONNECTION
+        params.add("dummy");
+        params.add(null); // debug address at position PARAM_IDX_DEBUG_ADDRESS
+        paramSet.add(params);
+        ExaIterator iter = new ExaIteratorDummy(paramSet);
+        ExaMetadata meta = mock(ExaMetadata.class);
+
+        try {
+            ExportIntoHiveTable.run(meta, iter);
+        } catch (NullPointerException npe) {
+            fail("A RuntimeException was expected, but not a NullPointerException!");
+        }
+    }
+
+    @Test
+    public void testHdfsUrlListSplit() throws Exception {
+        List<List<Object>> paramSet = new ArrayList<>();
+        List<Object> params = new ArrayList<>();
+        params.add("dummy");
+        params.add("dummy");
+        params.add("dummy");
+        params.add("dummy");
+        params.add("hdfs://__hdfsnn01:9999,hdfs://__hdfsnn02:9999,hdfs://__hdfsnn03:9999");
+        params.add("dummy");
+        params.add("dummy");
+        params.add("dummy");
+        params.add("dummy");
+        params.add("dummy");
+        params.add(null);
+        paramSet.add(params);
+        ExaIterator iter = new ExaIteratorDummy(paramSet);
+        ExaMetadata meta = mock(ExaMetadata.class);
+
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("no host: hdfs://__hdfsnn01:9999");
+        expectedException.expectMessage("no host: hdfs://__hdfsnn02:9999");
+        expectedException.expectMessage("no host: hdfs://__hdfsnn03:9999");
+        ExportIntoHiveTable.run(meta, iter);
+    }
 }


### PR DESCRIPTION
This should now add support for HDFS HA. Successfuly tested against a kerberized CDH 5.11.x Hadoop Cluster with HDFS HA enabled. #18 

Unit test is a bit awkward, because Mockito does not support mocking of static methods. Played around with PowerMock, but failed to get it running.