### PR TITLE
Use `AbstractSerDe` instead of `SerDe` in Import / Export Services

### DIFF
--- a/hadoop-etl-common/src/main/java/com/exasol/hadoop/HdfsSerDeImportService.java
+++ b/hadoop-etl-common/src/main/java/com/exasol/hadoop/HdfsSerDeImportService.java
@@ -19,7 +19,7 @@ import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.objectinspector.*;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableHiveDecimalObjectInspector;
@@ -82,8 +82,8 @@ public class HdfsSerDeImportService {
 
             System.out.println("run import");
             final InputFormat<?, ?> inputFormat = (InputFormat<?, ?>) UdfUtils.getInstanceByName(inputFormatClassName);
-            final SerDe serDe = (SerDe) UdfUtils.getInstanceByName(serDeClassName);
-            
+            final AbstractSerDe serDe = (AbstractSerDe) UdfUtils.getInstanceByName(serDeClassName);
+
             UserGroupInformation ugi = useKerberos ?
                     KerberosHadoopUtils.getKerberosUGI(kerberosCredentials) : UserGroupInformation.createRemoteUser(hdfsUserOrServicePrincipal);
             ugi.doAs(new PrivilegedExceptionAction<Void>() {
@@ -110,7 +110,7 @@ public class HdfsSerDeImportService {
             final String file,
             final List<HCatTableColumn> partitionColumns,
             final InputFormat<?, ?> inputFormat,
-            final SerDe serde,
+            final AbstractSerDe serde,
             final List<HCatSerDeParameter> serDeParameters,
             final List<String> hdfsUrls,
             final String hdfsUserOrServicePrincipal,

--- a/hadoop-etl-common/src/test/java/com/exasol/hadoop/HdfsSerDeExportServiceTest.java
+++ b/hadoop-etl-common/src/test/java/com/exasol/hadoop/HdfsSerDeExportServiceTest.java
@@ -11,7 +11,7 @@ import com.exasol.jsonpath.OutputColumnSpecUtil;
 import com.exasol.utils.UdfUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.mapred.InputFormat;
 import org.junit.Rule;
 import org.junit.Test;
@@ -408,7 +408,7 @@ public class HdfsSerDeExportServiceTest {
         final Configuration conf = new Configuration();
         FileSystem fs = HdfsService.getFileSystem(hdfsServers, conf);
         InputFormat<?, ?> inputFormat = (InputFormat<?, ?>) UdfUtils.getInstanceByName(inputFormatName);
-        SerDe serDe = (SerDe) UdfUtils.getInstanceByName(serdeName);
+        AbstractSerDe serDe = (AbstractSerDe) UdfUtils.getInstanceByName(serdeName);
         List<OutputColumnSpec> outputColumns = OutputColumnSpecUtil.generateDefaultOutputSpecification(columns, new ArrayList<HCatTableColumn>());
         HdfsSerDeImportService.importFile(fs, file, partitionColumns, inputFormat, serDe, serDeParameters, hdfsServers, hdfsUser, columns, outputColumns, useKerberos, false, ctx);
     }

--- a/hadoop-etl-common/src/test/java/com/exasol/hadoop/HdfsSerDeImportServiceTest.java
+++ b/hadoop-etl-common/src/test/java/com/exasol/hadoop/HdfsSerDeImportServiceTest.java
@@ -9,7 +9,7 @@ import com.exasol.jsonpath.OutputColumnSpecUtil;
 import com.exasol.utils.UdfUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.mapred.InputFormat;
 import org.junit.Test;
 
@@ -82,7 +82,7 @@ public class HdfsSerDeImportServiceTest {
         FileSystem fs = HdfsService.getFileSystem(hdfsServers,conf);
         
         InputFormat<?, ?> inputFormat = (InputFormat<?, ?>) UdfUtils.getInstanceByName(inputFormatClassName);
-        SerDe serDe = (SerDe) UdfUtils.getInstanceByName(serDeClassName);
+        AbstractSerDe serDe = (AbstractSerDe) UdfUtils.getInstanceByName(serDeClassName);
         HdfsSerDeImportService.importFile(fs, file, partitionColumns, inputFormat, serDe, serDeParameters, hdfsServers, hdfsUser, columns, outputColumns, useKerberos, false, ctx);
     }
     


### PR DESCRIPTION
With the release of Hive 2.3.0, the SerDe interface has been removed.

https://issues.apache.org/jira/browse/HIVE-15167