### PR TITLE
Use Apache Hadoop & Hive versions in default pom files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,16 @@ language: java
 
 matrix:
   include:
-    - jdk: "oraclejdk8"   # Maven build with default Hadoop (CDH)
-    - jdk: "oraclejdk8"   # Cloudera
+    - jdk: "oraclejdk8"   # Maven build with default Apache Hadoop
+
+    - jdk: "oraclejdk8"   # Apache Hadoop 2.8.5 Apache Hive 2.3.4
+      env: MVN_ARGS="-P apache -Dhadoop.version=2.8.5 -Dhive.version=2.3.4"
+
+    - jdk: "oraclejdk8"   # Cloudera CDH
       env: MVN_ARGS="-P cloudera -Dhadoop.version=2.6.0-cdh5.16.0 -Dhive.version=1.1.0-cdh5.16.0"
-    - jdk: "oraclejdk8"   # Cloudera
-      env: MVN_ARGS="-P cloudera -Dhadoop.version=2.6.0-cdh5.16.0 -Dhive.version=1.1.0-cdh5.16.0"
-    - jdk: "oraclejdk8"   # Hortonworks HDP Sandbox 2.6.3 (11.10.2017)
+
+    - jdk: "oraclejdk8"   # Hortonworks HDP
       env: MVN_ARGS="-P hortonworks -Dhadoop.version=2.7.3.2.6.5.3004-13 -Dhive.version=2.1.0.2.6.5.3004-13"
-    - jdk: "oraclejdk8"   # Apache Hadoop 2.8.4 Apache Hive 2.3.3 (for AWS EMR Release 5.17.0)
-      env: MVN_ARGS="-P cloudera-parquet -Dhadoop.version=2.8.5 -Dhive.version=2.3.4"
 
 # build a jar with all dependencies. Will also run tests.
 script: "mvn $MVN_ARGS install"

--- a/hadoop-etl-common/pom.xml
+++ b/hadoop-etl-common/pom.xml
@@ -14,8 +14,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <hadoop.version>2.6.0-cdh5.16.0</hadoop.version>
-        <hive.version>1.1.0-cdh5.16.0</hive.version>
+        <hadoop.version>2.8.5</hadoop.version>
+        <hive.version>2.3.4</hive.version>
     </properties>
 
     <repositories>
@@ -37,33 +37,27 @@
 
     <profiles>
         <profile>
-            <id>cloudera</id>
+            <id>apache</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <dependencies>
                 <dependency>
                     <groupId>com.exasol</groupId>
-                    <artifactId>parquet-pre-1.7</artifactId>
+                    <artifactId>parquet</artifactId>
                     <version>1.0.0-SNAPSHOT</version>
                 </dependency>
             </dependencies>
-            <repositories>
-                <repository>
-                    <id>cloudera</id>
-                    <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-                </repository>
-            </repositories>
         </profile>
         <profile>
-            <id>cloudera-parquet</id>
+            <id>cloudera</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
             <dependencies>
                 <dependency>
                     <groupId>com.exasol</groupId>
-                    <artifactId>parquet</artifactId>
+                    <artifactId>parquet-pre-1.7</artifactId>
                     <version>1.0.0-SNAPSHOT</version>
                 </dependency>
             </dependencies>

--- a/hadoop-etl-dist/pom.xml
+++ b/hadoop-etl-dist/pom.xml
@@ -17,27 +17,27 @@
 
     <profiles>
         <profile>
-            <id>cloudera</id>
+            <id>apache</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <dependencies>
                 <dependency>
                     <groupId>com.exasol</groupId>
-                    <artifactId>parquet-pre-1.7</artifactId>
+                    <artifactId>parquet</artifactId>
                     <version>1.0.0-SNAPSHOT</version>
                 </dependency>
             </dependencies>
         </profile>
         <profile>
-            <id>cloudera-parquet</id>
+            <id>cloudera</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
             <dependencies>
                 <dependency>
                     <groupId>com.exasol</groupId>
-                    <artifactId>parquet</artifactId>
+                    <artifactId>parquet-pre-1.7</artifactId>
                     <version>1.0.0-SNAPSHOT</version>
                 </dependency>
             </dependencies>

--- a/parquet-pre-1.7/pom.xml
+++ b/parquet-pre-1.7/pom.xml
@@ -14,8 +14,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<hadoop.version>2.6.0-cdh5.16.0</hadoop.version>
-		<hive.version>1.1.0-cdh5.16.0</hive.version>
+		<hadoop.version>2.8.5</hadoop.version>
+		<hive.version>2.3.4</hive.version>
 	</properties>
 
 	<repositories>
@@ -37,19 +37,13 @@
 
 	<profiles>
 		<profile>
-			<id>cloudera</id>
+			<id>apache</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
-			<repositories>
-				<repository>
-					<id>cloudera</id>
-					<url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-				</repository>
-			</repositories>
 		</profile>
 		<profile>
-			<id>cloudera-parquet</id>
+			<id>cloudera</id>
 			<activation>
 				<activeByDefault>false</activeByDefault>
 			</activation>

--- a/parquet/pom.xml
+++ b/parquet/pom.xml
@@ -14,8 +14,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<hadoop.version>2.6.0-cdh5.16.0</hadoop.version>
-		<hive.version>1.1.0-cdh5.16.0</hive.version>
+		<hadoop.version>2.8.5</hadoop.version>
+		<hive.version>2.3.4</hive.version>
 	</properties>
 
 	<repositories>
@@ -37,23 +37,17 @@
 
 	<profiles>
 		<profile>
-			<id>cloudera</id>
+			<id>apache</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
-			<repositories>
-				<repository>
-					<id>cloudera</id>
-					<url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-				</repository>
-			</repositories>
 		</profile>
 		<profile>
-			<id>cloudera-parquet</id>
+			<id>cloudera</id>
 			<activation>
 				<activeByDefault>false</activeByDefault>
 			</activation>
-			<repositories>
+                        <repositories>
 				<repository>
 					<id>cloudera</id>
 					<url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<hadoop.version>2.6.0-cdh5.16.0</hadoop.version>
-		<hive.version>1.1.0-cdh5.16.0</hive.version>
+		<hadoop.version>2.8.5</hadoop.version>
+		<hive.version>2.3.4</hive.version>
 	</properties>
 
     <repositories>
@@ -34,7 +34,7 @@
 
     <profiles>
         <profile>
-            <id>cloudera</id>
+            <id>apache</id>
             <!-- If true, this profile is automatically active for all builds, unless another profile gets activated-->
             <activation>
                 <activeByDefault>true</activeByDefault>
@@ -42,19 +42,19 @@
             <modules>
                 <module>hadoop-etl-common</module>
                 <module>exa-parquet-api</module>
-                <module>parquet-pre-1.7</module>
+                <module>parquet</module>
                 <module>hadoop-etl-dist</module>
             </modules>
         </profile>
         <profile>
-            <id>cloudera-parquet</id>
+            <id>cloudera</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
             <modules>
                 <module>hadoop-etl-common</module>
                 <module>exa-parquet-api</module>
-                <module>parquet</module>
+                <module>parquet-pre-1.7</module>
                 <module>hadoop-etl-dist</module>
             </modules>
         </profile>


### PR DESCRIPTION
Changes default profile to `apache`.

With this Cloudera CDH still uses the `parquet-pre-1.7` libraries. In the future we can also make another profile to compile CDH with latest parquet versions.