### PR TITLE
Fix unimplemented method `getScopeUser()` in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ matrix:
 
 # build a jar with all dependencies. Will also run tests.
 script: "mvn $MVN_ARGS install"
+
+cache:
+  directories:
+    - $HOME/.m2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hadoop ETL UDFs
 
-[![Build Status](https://travis-ci.org/EXASOL/hadoop-etl-udfs.svg?branch=master)](https://travis-ci.org/EXASOL/hadoop-etl-udfs)
+[![Build Status](https://travis-ci.org/exasol/hadoop-etl-udfs.svg?branch=master)](https://travis-ci.org/exasol/hadoop-etl-udfs)
 
 
 ###### Please note that this is an open source project which is officially supported by Exasol. For any questions, you can contact our support team. Please note, however, that the EXPORT functionality is still in BETA mode.

--- a/hadoop-etl-common/src/test/java/com/exasol/ExaMetadataDummy.java
+++ b/hadoop-etl-common/src/test/java/com/exasol/ExaMetadataDummy.java
@@ -43,6 +43,11 @@ public class ExaMetadataDummy implements ExaMetadata {
     }
 
     @Override
+    public String getScopeUser() {
+        throw new NotImplementedException("Not yet implemented");
+    }
+
+    @Override
     public String getCurrentSchema() {
         throw new NotImplementedException("Not yet implemented");
     }


### PR DESCRIPTION
Fixes unimplemented method `getScopeUser()` in ExaMetadataDummy.java in tests. 

**Other minor changes:**

- Change travis links in readme
- Add maven `.m2` cache directories to `.travis.yml`