### PR TITLE
Fix ClassCastException for URLClassLoader when running with Java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 # Builds an uber-jar with all dependencies.
 script: "mvn $MVN_ARGS install"
 
-# Removes install outputs so that cache is stable.
+# Removes install outputs so that the cache is stable.
 before_cache:
   - rm -rf $HOME/.m2/repository/com/exasol
   - find $HOME/.m2 -name resolver-status.properties -exec rm {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - MVN_ARGS="-P mapr -Dhadoop.version=2.7.0-mapr-1602 -Dhive.version=2.0.0-mapr-1605 -DskipTests=true"
 
 # Builds an uber-jar with all dependencies.
-script: "mvn $MVN_ARGS install"
+script: "mvn $MVN_ARGS clean install"
 
 # Removes install outputs so that the cache is stable.
 before_cache:


### PR DESCRIPTION
- Depending on the Java version, uses different mechanism in order to obtain urls from class loader.
- I used similar solution approach as in [Spring Boot](https://github.com/spring-projects/spring-boot/issues/10454) project.

Fixes #39.